### PR TITLE
Move the tenant label to the front

### DIFF
--- a/src/next-client.js
+++ b/src/next-client.js
@@ -1,7 +1,7 @@
 // Constants
 const TENANT = 'example';
 const TOKEN = 'my-next-token';
-const API_ENDPOINT = `https://api.${TENANT}.nextapp.co/v1/opportunities`;
+const API_ENDPOINT = `https://${TENANT}.api.nextapp.co/v1/opportunities`;
 const APP_ENDPOINT = `https://${TENANT}.nextapp.co/app/`;
 
 /**


### PR DESCRIPTION
It's really difficult, if not impossible, to produce nice certificates in the 'X.*.Y' format. While we can, let's jjust avoid the headache and move things.